### PR TITLE
Add setup-rclone action

### DIFF
--- a/setup-rclone/action.yml
+++ b/setup-rclone/action.yml
@@ -1,5 +1,5 @@
 name: setup-rclone
-description: Installs rclone (linux x64)
+description: Installs rclone (linux amd64)
 
 inputs:
   version:

--- a/setup-rclone/action.yml
+++ b/setup-rclone/action.yml
@@ -22,7 +22,7 @@ runs:
         tmp_bin_dir="$(mktemp -d $RUNNER_TEMP/XXXXXXXXXX)"
         rclone_bin="$tmp_bin_dir/rclone"
         mv rclone-v${RCLONE_VERSION}-linux-amd64/rclone "$rclone_bin"
-        rm -fr MD5SUMS rclone-v${RCLONE_VERSION}-linux-amd64
+        rm -fr MD5SUMS rclone-v${RCLONE_VERSION}-linux-amd64.zip rclone-v${RCLONE_VERSION}-linux-amd64
         chmod +x "$rclone_bin"
         echo "$tmp_bin_dir" >> $GITHUB_PATH
       env:

--- a/setup-rclone/action.yml
+++ b/setup-rclone/action.yml
@@ -24,6 +24,7 @@ runs:
         mv rclone-v${RCLONE_VERSION}-linux-amd64/rclone "$rclone_bin"
         rm -fr MD5SUMS rclone-v${RCLONE_VERSION}-linux-amd64.zip rclone-v${RCLONE_VERSION}-linux-amd64
         chmod +x "$rclone_bin"
+        $rclone_bin config touch
         echo "$tmp_bin_dir" >> $GITHUB_PATH
       env:
         RCLONE_VERSION: ${{ inputs.version }}

--- a/setup-rclone/action.yml
+++ b/setup-rclone/action.yml
@@ -12,19 +12,19 @@ runs:
     - id: setup
       shell: bash
       run: |
-        download_base_url="https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}"
-        zip_download_url="${download_base_url}/rclone-v${RCLONE_VERSION}-linux-amd64.zip"
+        download_base_url="https://github.com/rclone/rclone/releases/download/v${VERSION}"
+        zip_download_url="${download_base_url}/rclone-v${VERSION}-linux-amd64.zip"
         md5sums_download_url="${download_base_url}/MD5SUMS"
         curl -fsSLOJ --retry 3 "$zip_download_url"
         curl -fsSLOJ --retry 3 "$md5sums_download_url"
         md5sum -c --ignore-missing 2>/dev/null MD5SUMS
-        unzip rclone-v${RCLONE_VERSION}-linux-amd64.zip
+        unzip rclone-v${VERSION}-linux-amd64.zip
         tmp_bin_dir="$(mktemp -d $RUNNER_TEMP/XXXXXXXXXX)"
         rclone_bin="$tmp_bin_dir/rclone"
-        mv rclone-v${RCLONE_VERSION}-linux-amd64/rclone "$rclone_bin"
-        rm -fr MD5SUMS rclone-v${RCLONE_VERSION}-linux-amd64.zip rclone-v${RCLONE_VERSION}-linux-amd64
+        mv rclone-v${VERSION}-linux-amd64/rclone "$rclone_bin"
+        rm -fr MD5SUMS rclone-v${VERSION}-linux-amd64.zip rclone-v${VERSION}-linux-amd64
         chmod +x "$rclone_bin"
         $rclone_bin config touch
         echo "$tmp_bin_dir" >> $GITHUB_PATH
       env:
-        RCLONE_VERSION: ${{ inputs.version }}
+        VERSION: ${{ inputs.version }}

--- a/setup-rclone/action.yml
+++ b/setup-rclone/action.yml
@@ -1,0 +1,29 @@
+name: setup-rclone
+description: Installs rclone (linux x64)
+
+inputs:
+  version:
+    description: Version, e.g. '1.60.1'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: setup
+      shell: bash
+      run: |
+        download_base_url="https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}"
+        zip_download_url="${download_base_url}/rclone-v${RCLONE_VERSION}-linux-amd64.zip"
+        md5sums_download_url="${download_base_url}/MD5SUMS"
+        curl -fsSLOJ --retry 3 "$zip_download_url"
+        curl -fsSLOJ --retry 3 "$md5sums_download_url"
+        md5sum -c --ignore-missing 2>/dev/null MD5SUMS
+        unzip rclone-v${RCLONE_VERSION}-linux-amd64.zip
+        tmp_bin_dir="$(mktemp -d $RUNNER_TEMP/XXXXXXXXXX)"
+        rclone_bin="$tmp_bin_dir/rclone"
+        mv rclone-v${RCLONE_VERSION}-linux-amd64/rclone "$rclone_bin"
+        rm -fr MD5SUMS rclone-v${RCLONE_VERSION}-linux-amd64
+        chmod +x "$rclone_bin"
+        echo "$tmp_bin_dir" >> $GITHUB_PATH
+      env:
+        RCLONE_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
So we can install a recent version of [rclone](https://rclone.org/), which can be used for e.g. syncing content to s3 (or r2) buckets