### PR TITLE
Helper to unset environment variables

### DIFF
--- a/unset-env-vars/action.yml
+++ b/unset-env-vars/action.yml
@@ -1,0 +1,15 @@
+name: unset-env-vars
+description: Unset given environment variables
+
+inputs:
+  env-vars:
+    description: Space separated environment variable names to unset, ex. "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: for e in $ENV_VARS; do echo "$e=" >> $GITHUB_ENV; done
+      env:
+        ENV_VARS: ${{ inputs.env-vars }}

--- a/unset-env-vars/action.yml
+++ b/unset-env-vars/action.yml
@@ -2,7 +2,7 @@ name: unset-env-vars
 description: Unset given environment variables
 
 inputs:
-  env-vars:
+  names:
     description: Space separated environment variable names to unset, ex. "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY"
     required: true
 
@@ -10,6 +10,6 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: for e in $ENV_VARS; do echo "$e=" >> $GITHUB_ENV; done
+      run: for e in $NAMES; do echo "$e=" >> $GITHUB_ENV; done
       env:
-        ENV_VARS: ${{ inputs.env-vars }}
+        NAMES: ${{ inputs.names }}


### PR DESCRIPTION
```
uses: pafcloud/helper-actions/unset-env-vars
with:
  names: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
```