### PR TITLE
Fix to field for aws ses send email

### DIFF
--- a/send-email-ses/action.yml
+++ b/send-email-ses/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     
-    - run: aws ses send-email --from "$FROM" --to "$TO" --subject "$SUBJECT" --html "$BODY"
+    - run: aws ses send-email --from "$FROM" --to $TO --subject "$SUBJECT" --html "$BODY"
       shell: bash
       env:
         FROM: ${{ inputs.from }}


### PR DESCRIPTION
Double quotes in the TO field causes issues when sending emails to multiple recipients. 

```
aws ses send-email --from "ses@paf.com" --to "johan.karlsson@paf.com henrik.tellander@paf.com" --subject "test1" --html "my html body"

An error occurred (InvalidParameterValue) when calling the SendEmail operation: Domain contains control or whitespace
```

vs

```
aws ses send-email --from "ses@paf.com" --to johan.karlsson@paf.com henrik.tellander@paf.com --subject "test1" --html "my html body"  
{
    "MessageId": "0102018f80c58ddc-8241900d-03be-43f8-b087-96b3e0712e97-000000"
}
```

